### PR TITLE
Add Retry-After header and fix rate limiting behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,38 +73,82 @@ Prometheus metrics endpoint that exposes the following metrics:
 
 ## Examples
 
-Try `/allow` endpoint with `wrk`:
+### Try `/allow` endpoint with [vegeta](https://github.com/tsenart/vegeta).
 
-```
-$ wrk -c 10 -t 4 -d 10 "http://localhost:8000/allow?key=foo&rate=100&burst=100"
-Running 10s test @ http://localhost:8000/allow?key=foo&rate=100&burst=100
-  4 threads and 10 connections
-  Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency   214.22us  151.33us   4.42ms   90.35%
-    Req/Sec     9.26k   663.14    10.24k    78.96%
-  372198 requests in 10.10s, 53.90MB read
-  Non-2xx or 3xx responses: 372098
-Requests/sec:  36849.90
-Transfer/sec:      5.34MB
-```
+#### Send 50 req/sec for 10 seconds.
 
-372198(total) - 372098(Non-2xx or 3xx) = 100 requests allowed.
+- All requests are allowed because the rate limit is high enough (100 req/sec).
 
-Try `/wait` endpoint with `wrk`:
-
-```
-$ wrk -c 10 -t 4 -d 10 "http://localhost:8000/wait?key=foo&rate=100&burst=100"
-Running 10s test @ http://localhost:8000/wait?key=foo&rate=100&burst=100
-  4 threads and 10 connections
-  Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    72.48ms   23.15ms  81.14ms   90.46%
-    Req/Sec    27.53     25.74   280.00     99.00%
-  1101 requests in 10.01s, 111.82KB read
-Requests/sec:    109.96
-Transfer/sec:     11.17KB
+```console
+$ echo "GET http://localhost:8000/allow?key=foo&rate=100&burst=100" \
+  | vegeta attack -rate=50/s -duration=10s \
+  | vegeta report
+Requests      [total, rate, throughput]  500, 50.10, 50.09
+Duration      [total, attack, wait]      9.981370923s, 9.980667035s, 703.888µs
+Latencies     [mean, 50, 95, 99, max]    755.588µs, 732.06µs, 974.465µs, 1.314326ms, 1.875267ms
+Bytes In      [total, mean]              1500, 3.00
+Bytes Out     [total, mean]              0, 0.00
+Success       [ratio]                    100.00%
+Status Codes  [code:count]               200:500
 ```
 
-Requests are throttled to about 100 req/sec. (first 100 requests are allowed immediately by burst=100)
+#### Send 150 req/sec for 10 seconds.
+
+- Some requests are rate-limited because the rate limit is 100 req/sec and the burst is 100.
+
+```
+$ echo "GET http://localhost:8000/allow?key=foo&rate=100&burst=100" \
+  | vegeta attack -rate=150/s -duration=10s \
+  | vegeta report
+Requests      [total, rate, throughput]  1500, 150.10, 109.97
+Duration      [total, attack, wait]      9.993624552s, 9.993018463s, 606.089µs
+Latencies     [mean, 50, 95, 99, max]    638.554µs, 622.971µs, 822.782µs, 996.477µs, 1.793067ms
+Bytes In      [total, mean]              10515, 7.01
+Bytes Out     [total, mean]              0, 0.00
+Success       [ratio]                    73.27%
+Status Codes  [code:count]               200:1099  429:401
+Error Set:
+429 Too Many Requests
+```
+
+### Try `/wait` endpoint with [vegeta](https://github.com/tsenart/vegeta).
+
+#### Send 50 req/sec for 10 seconds.
+
+- All requests are allowed.
+- All requests are processed quickly because the rate limit is high enough (100 req/sec).
+
+```console
+$ echo "GET http://localhost:8000/wait?key=foo&rate=100&burst=100" \
+  | vegeta attack -rate=50/s -duration=10s \
+  | vegeta report
+Requests      [total, rate, throughput]  500, 50.10, 50.10
+Duration      [total, attack, wait]      9.980926429s, 9.980267941s, 658.488µs
+Latencies     [mean, 50, 95, 99, max]    783.105µs, 743.842µs, 1.077636ms, 1.277127ms, 2.447456ms
+Bytes In      [total, mean]              1500, 3.00
+Bytes Out     [total, mean]              0, 0.00
+Success       [ratio]                    100.00%
+Status Codes  [code:count]               200:500
+```
+
+#### Send 150 req/sec for 10 seconds.
+
+- All requests are eventually allowed because `/wait` waits until allowed.
+- Some requests take longer to be processed due to waiting.
+- `throughput` is near the rate limit (100 req/sec).
+
+```
+$ echo "GET http://localhost:8000/wait?key=foo&rate=100&burst=100" \
+  | vegeta attack -rate=150/s -duration=10s \
+  | vegeta report
+Requests      [total, rate, throughput]  1500, 150.10, 107.13
+Duration      [total, attack, wait]      14.002010846s, 9.993653515s, 4.008357331s
+Latencies     [mean, 50, 95, 99, max]    1.608736286s, 1.510623673s, 3.760693909s, 3.960715362s, 4.008357331s
+Bytes In      [total, mean]              4500, 3.00
+Bytes Out     [total, mean]              0, 0.00
+Success       [ratio]                    100.00%
+Status Codes  [code:count]               200:1500
+```
 
 ## LICENSE
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ GET /allow?key=${identifier}&rate=${rate}&burst=${burst}
 
 - 200: OK. Allowed by a rate limiter.
 - 201: A rate limiter for `key` was created.
-- 429: Not allowed by a rate limiter.
+- 429: Not allowed by a rate limiter. Includes `Retry-After` header with suggested wait time in seconds.
 
 ### /wait
 
@@ -55,7 +55,7 @@ If a request is not allowed `/wait` waits until allowed, and returns a response.
 
 - 200: OK. Allowed by a rate limiter.
 - 201: A rate limiter for `key` was created.
-- 429: Not allowed by a rate limiter.
+- 429: Not allowed by a rate limiter. Includes `Retry-After` header with suggested wait time in seconds.
 
 ### /metrics
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ $ throttled --port PORT [--size CACHE_SIZE]
 
 **Note about burst parameter:**
 - `burst` represents the maximum number of tokens that can be stored in the bucket
-- When `burst=0`, no tokens can be stored, effectively blocking all requests after the initial limiter creation
-- The first request with a new key returns 201 (limiter created), but subsequent requests will always return 429
+- When `burst=0`, no tokens can be stored, effectively blocking all requests immediately
 - For practical use, set `burst` to at least 1
 
 ### /allow
@@ -39,7 +38,6 @@ GET /allow?key=${identifier}&rate=${rate}&burst=${burst}
 `/allow` returns a response immediately.
 
 - 200: OK. Allowed by a rate limiter.
-- 201: A rate limiter for `key` was created.
 - 429: Not allowed by a rate limiter. Includes `Retry-After` header with suggested wait time in seconds.
 
 ### /wait
@@ -54,8 +52,7 @@ GET /wait?key=${identifier}&rate=${rate}&burst=${burst}
 If a request is not allowed `/wait` waits until allowed, and returns a response.
 
 - 200: OK. Allowed by a rate limiter.
-- 201: A rate limiter for `key` was created.
-- 429: Not allowed by a rate limiter. Includes `Retry-After` header with suggested wait time in seconds.
+- 429: Not allowed by a rate limiter (context timeout). Includes `Retry-After` header with suggested wait time in seconds.
 
 ### /metrics
 

--- a/README.md
+++ b/README.md
@@ -73,32 +73,38 @@ Prometheus metrics endpoint that exposes the following metrics:
 
 ## Examples
 
-```
-$ wrk -c 10 -t 4 -d 10 "http://localhost:8888/allow?key=foo&rate=100&burst=100"
-Running 10s test @ http://localhost:8888/allow?key=foo&rate=100&burst=100
-  4 threads and 10 connections
-  Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency   274.56us  838.09us  32.03ms   97.65%
-    Req/Sec    10.64k     0.99k   13.59k    75.68%
-  426613 requests in 10.10s, 54.89MB read
-  Non-2xx or 3xx responses: 425502
-Requests/sec:  42236.34
-Transfer/sec:      5.43MB
-```
-
-426613(total) - 425502(Non-2xx or 3xx) = 1111 / 10.10s =~ 110 req/sec
+Try `/allow` endpoint with `wrk`:
 
 ```
-$ wrk -c 10 -t 4 -d 10 "http://localhost:8888/wait?key=foo&rate=100&burst=100"
-Running 10s test @ http://localhost:8888/wait?key=foo&rate=100&burst=100
+$ wrk -c 10 -t 4 -d 10 "http://localhost:8000/allow?key=foo&rate=100&burst=100"
+Running 10s test @ http://localhost:8000/allow?key=foo&rate=100&burst=100
   4 threads and 10 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency    72.43ms   23.23ms  82.63ms   90.40%
-    Req/Sec    27.33     25.79   290.00     98.99%
-  1104 requests in 10.05s, 112.13KB read
-Requests/sec:    109.82
-Transfer/sec:     11.15KB
+    Latency   214.22us  151.33us   4.42ms   90.35%
+    Req/Sec     9.26k   663.14    10.24k    78.96%
+  372198 requests in 10.10s, 53.90MB read
+  Non-2xx or 3xx responses: 372098
+Requests/sec:  36849.90
+Transfer/sec:      5.34MB
 ```
+
+372198(total) - 372098(Non-2xx or 3xx) = 100 requests allowed.
+
+Try `/wait` endpoint with `wrk`:
+
+```
+$ wrk -c 10 -t 4 -d 10 "http://localhost:8000/wait?key=foo&rate=100&burst=100"
+Running 10s test @ http://localhost:8000/wait?key=foo&rate=100&burst=100
+  4 threads and 10 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency    72.48ms   23.15ms  81.14ms   90.46%
+    Req/Sec    27.53     25.74   280.00     99.00%
+  1101 requests in 10.01s, 111.82KB read
+Requests/sec:    109.96
+Transfer/sec:     11.17KB
+```
+
+Requests are throttled to about 100 req/sec. (first 100 requests are allowed immediately by burst=100)
 
 ## LICENSE
 

--- a/retry_after_test.go
+++ b/retry_after_test.go
@@ -21,29 +21,20 @@ func TestRetryAfterHeader(t *testing.T) {
 	w1 := httptest.NewRecorder()
 	s.Handler.ServeHTTP(w1, req1)
 
-	if w1.Code != http.StatusCreated {
-		t.Errorf("Expected status 201, got %d", w1.Code)
+	if w1.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", w1.Code)
 	}
 
-	// Second request should use the burst token and succeed
+	// Second request should hit rate limit and include Retry-After header
 	req2, _ := http.NewRequest("GET", "/allow?key=test_retry&rate=1&burst=1", nil)
 	w2 := httptest.NewRecorder()
 	s.Handler.ServeHTTP(w2, req2)
 
-	if w2.Code != http.StatusOK {
-		t.Errorf("Expected status 200, got %d", w2.Code)
+	if w2.Code != http.StatusTooManyRequests {
+		t.Errorf("Expected status 429, got %d", w2.Code)
 	}
 
-	// Third request should hit rate limit and include Retry-After header
-	req3, _ := http.NewRequest("GET", "/allow?key=test_retry&rate=1&burst=1", nil)
-	w3 := httptest.NewRecorder()
-	s.Handler.ServeHTTP(w3, req3)
-
-	if w3.Code != http.StatusTooManyRequests {
-		t.Errorf("Expected status 429, got %d", w3.Code)
-	}
-
-	retryAfter := w3.Header().Get("Retry-After")
+	retryAfter := w2.Header().Get("Retry-After")
 	if retryAfter == "" {
 		t.Error("Retry-After header not found")
 	}
@@ -69,29 +60,20 @@ func TestRetryAfterWithSlowRate(t *testing.T) {
 	w1 := httptest.NewRecorder()
 	s.Handler.ServeHTTP(w1, req1)
 
-	if w1.Code != http.StatusCreated {
-		t.Errorf("Expected status 201, got %d", w1.Code)
+	if w1.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", w1.Code)
 	}
 
-	// Second request should use burst token
+	// Second request should hit rate limit
 	req2, _ := http.NewRequest("GET", "/allow?key=test_slow&rate=0.1&burst=1", nil)
 	w2 := httptest.NewRecorder()
 	s.Handler.ServeHTTP(w2, req2)
 
-	if w2.Code != http.StatusOK {
-		t.Errorf("Expected status 200, got %d", w2.Code)
+	if w2.Code != http.StatusTooManyRequests {
+		t.Errorf("Expected status 429, got %d", w2.Code)
 	}
 
-	// Third request should hit rate limit
-	req3, _ := http.NewRequest("GET", "/allow?key=test_slow&rate=0.1&burst=1", nil)
-	w3 := httptest.NewRecorder()
-	s.Handler.ServeHTTP(w3, req3)
-
-	if w3.Code != http.StatusTooManyRequests {
-		t.Errorf("Expected status 429, got %d", w3.Code)
-	}
-
-	retryAfter := w3.Header().Get("Retry-After")
+	retryAfter := w2.Header().Get("Retry-After")
 	if retryAfter == "" {
 		t.Error("Retry-After header not found")
 	}
@@ -139,28 +121,23 @@ func TestRetryAfterRespectsTiming(t *testing.T) {
 	w1 := httptest.NewRecorder()
 	s.Handler.ServeHTTP(w1, req1)
 
-	// Use up the burst token
+	// Get rate limit response with Retry-After
 	req2, _ := http.NewRequest("GET", "/allow?key=test_timing&rate=2&burst=1", nil)
 	w2 := httptest.NewRecorder()
 	s.Handler.ServeHTTP(w2, req2)
 
-	// Get rate limit response with Retry-After
-	req3, _ := http.NewRequest("GET", "/allow?key=test_timing&rate=2&burst=1", nil)
-	w3 := httptest.NewRecorder()
-	s.Handler.ServeHTTP(w3, req3)
-
-	retryAfter := w3.Header().Get("Retry-After")
+	retryAfter := w2.Header().Get("Retry-After")
 	retrySeconds, _ := strconv.Atoi(retryAfter)
 
 	// Wait for the suggested time
 	time.Sleep(time.Duration(retrySeconds) * time.Second)
 
 	// Next request should succeed
-	req4, _ := http.NewRequest("GET", "/allow?key=test_timing&rate=2&burst=1", nil)
-	w4 := httptest.NewRecorder()
-	s.Handler.ServeHTTP(w4, req4)
+	req3, _ := http.NewRequest("GET", "/allow?key=test_timing&rate=2&burst=1", nil)
+	w3 := httptest.NewRecorder()
+	s.Handler.ServeHTTP(w3, req3)
 
-	if w4.Code != http.StatusOK {
-		t.Errorf("Expected request to succeed after waiting, got status %d", w4.Code)
+	if w3.Code != http.StatusOK {
+		t.Errorf("Expected request to succeed after waiting, got status %d", w3.Code)
 	}
 }

--- a/retry_after_test.go
+++ b/retry_after_test.go
@@ -1,0 +1,166 @@
+package throttled_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/fujiwara/throttled"
+)
+
+func TestRetryAfterHeader(t *testing.T) {
+	s, err := throttled.NewServer(1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create limiter with burst=1, rate=1 req/sec
+	req1, _ := http.NewRequest("GET", "/allow?key=test_retry&rate=1&burst=1", nil)
+	w1 := httptest.NewRecorder()
+	s.Handler.ServeHTTP(w1, req1)
+
+	if w1.Code != http.StatusCreated {
+		t.Errorf("Expected status 201, got %d", w1.Code)
+	}
+
+	// Second request should use the burst token and succeed
+	req2, _ := http.NewRequest("GET", "/allow?key=test_retry&rate=1&burst=1", nil)
+	w2 := httptest.NewRecorder()
+	s.Handler.ServeHTTP(w2, req2)
+
+	if w2.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", w2.Code)
+	}
+
+	// Third request should hit rate limit and include Retry-After header
+	req3, _ := http.NewRequest("GET", "/allow?key=test_retry&rate=1&burst=1", nil)
+	w3 := httptest.NewRecorder()
+	s.Handler.ServeHTTP(w3, req3)
+
+	if w3.Code != http.StatusTooManyRequests {
+		t.Errorf("Expected status 429, got %d", w3.Code)
+	}
+
+	retryAfter := w3.Header().Get("Retry-After")
+	if retryAfter == "" {
+		t.Error("Retry-After header not found")
+	}
+
+	retrySeconds, err := strconv.Atoi(retryAfter)
+	if err != nil {
+		t.Errorf("Invalid Retry-After value: %s", retryAfter)
+	}
+
+	if retrySeconds <= 0 || retrySeconds > 2 {
+		t.Errorf("Expected Retry-After to be 1-2 seconds, got %d", retrySeconds)
+	}
+}
+
+func TestRetryAfterWithSlowRate(t *testing.T) {
+	s, err := throttled.NewServer(1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create limiter with burst=1, rate=0.1 req/sec (10 second interval)
+	req1, _ := http.NewRequest("GET", "/allow?key=test_slow&rate=0.1&burst=1", nil)
+	w1 := httptest.NewRecorder()
+	s.Handler.ServeHTTP(w1, req1)
+
+	if w1.Code != http.StatusCreated {
+		t.Errorf("Expected status 201, got %d", w1.Code)
+	}
+
+	// Second request should use burst token
+	req2, _ := http.NewRequest("GET", "/allow?key=test_slow&rate=0.1&burst=1", nil)
+	w2 := httptest.NewRecorder()
+	s.Handler.ServeHTTP(w2, req2)
+
+	if w2.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", w2.Code)
+	}
+
+	// Third request should hit rate limit
+	req3, _ := http.NewRequest("GET", "/allow?key=test_slow&rate=0.1&burst=1", nil)
+	w3 := httptest.NewRecorder()
+	s.Handler.ServeHTTP(w3, req3)
+
+	if w3.Code != http.StatusTooManyRequests {
+		t.Errorf("Expected status 429, got %d", w3.Code)
+	}
+
+	retryAfter := w3.Header().Get("Retry-After")
+	if retryAfter == "" {
+		t.Error("Retry-After header not found")
+	}
+
+	retrySeconds, err := strconv.Atoi(retryAfter)
+	if err != nil {
+		t.Errorf("Invalid Retry-After value: %s", retryAfter)
+	}
+
+	// Should be around 10 seconds
+	if retrySeconds < 9 || retrySeconds > 11 {
+		t.Errorf("Expected Retry-After to be around 10 seconds, got %d", retrySeconds)
+	}
+}
+
+func TestRetryAfterNotSetOnSuccess(t *testing.T) {
+	s, err := throttled.NewServer(1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Request that should succeed
+	req, _ := http.NewRequest("GET", "/allow?key=test_success&rate=10&burst=10", nil)
+	w := httptest.NewRecorder()
+	s.Handler.ServeHTTP(w, req)
+
+	if w.Code == http.StatusTooManyRequests {
+		t.Errorf("Expected non-429 status, got %d", w.Code)
+	}
+
+	retryAfter := w.Header().Get("Retry-After")
+	if retryAfter != "" {
+		t.Errorf("Retry-After header should not be set on successful request, got: %s", retryAfter)
+	}
+}
+
+func TestRetryAfterRespectsTiming(t *testing.T) {
+	s, err := throttled.NewServer(1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create limiter with burst=1, rate=2 req/sec (0.5 second interval)
+	req1, _ := http.NewRequest("GET", "/allow?key=test_timing&rate=2&burst=1", nil)
+	w1 := httptest.NewRecorder()
+	s.Handler.ServeHTTP(w1, req1)
+
+	// Use up the burst token
+	req2, _ := http.NewRequest("GET", "/allow?key=test_timing&rate=2&burst=1", nil)
+	w2 := httptest.NewRecorder()
+	s.Handler.ServeHTTP(w2, req2)
+
+	// Get rate limit response with Retry-After
+	req3, _ := http.NewRequest("GET", "/allow?key=test_timing&rate=2&burst=1", nil)
+	w3 := httptest.NewRecorder()
+	s.Handler.ServeHTTP(w3, req3)
+
+	retryAfter := w3.Header().Get("Retry-After")
+	retrySeconds, _ := strconv.Atoi(retryAfter)
+
+	// Wait for the suggested time
+	time.Sleep(time.Duration(retrySeconds) * time.Second)
+
+	// Next request should succeed
+	req4, _ := http.NewRequest("GET", "/allow?key=test_timing&rate=2&burst=1", nil)
+	w4 := httptest.NewRecorder()
+	s.Handler.ServeHTTP(w4, req4)
+
+	if w4.Code != http.StatusOK {
+		t.Errorf("Expected request to succeed after waiting, got status %d", w4.Code)
+	}
+}

--- a/throttled.go
+++ b/throttled.go
@@ -2,6 +2,7 @@ package throttled
 
 import (
 	"fmt"
+	"math"
 	"net/http"
 	"strconv"
 	"time"
@@ -102,7 +103,7 @@ func (s *Server) runLimiter(w http.ResponseWriter, r *http.Request, wait bool) {
 				s.response(w, http.StatusOK)
 			} else {
 				rateLimitHitsTotal.Inc()
-				s.response(w, http.StatusTooManyRequests)
+				s.responseWithRetryAfter(w, http.StatusTooManyRequests, l)
 			}
 		}
 	}
@@ -133,12 +134,35 @@ func (s *Server) instrumentHandler(endpoint string, handler http.HandlerFunc) ht
 	}
 }
 
+func (s *Server) responseWithRetryAfter(w http.ResponseWriter, code int, limiter *rate.Limiter) {
+	w.Header().Set("Content-Type", "text/plain")
+
+	// Reserve()を使って次のトークンが利用可能になるまでの時間を計算
+	r := limiter.Reserve()
+	delay := r.Delay()
+	r.Cancel() // 実際には予約しないのでキャンセル
+
+	// Retry-Afterヘッダーに秒数を設定（切り上げ）
+	retryAfterSeconds := int(math.Ceil(delay.Seconds()))
+	if retryAfterSeconds > 0 {
+		w.Header().Set("Retry-After", strconv.Itoa(retryAfterSeconds))
+	}
+
+	w.WriteHeader(code)
+	fmt.Fprintln(w, http.StatusText(code))
+}
+
 type statusRecorder struct {
 	http.ResponseWriter
-	statusCode int
+	statusCode    int
+	headerWritten bool
 }
 
 func (r *statusRecorder) WriteHeader(code int) {
+	if r.headerWritten {
+		return
+	}
 	r.statusCode = code
+	r.headerWritten = true
 	r.ResponseWriter.WriteHeader(code)
 }

--- a/throttled.go
+++ b/throttled.go
@@ -65,10 +65,11 @@ func parseLimitRequest(r *http.Request) (*LimitRequest, error) {
 	}, nil
 }
 
-func (s *Server) newLimiter(rv *LimitRequest) {
+func (s *Server) newLimiter(rv *LimitRequest) *rate.Limiter {
 	l := rate.NewLimiter(rv.Rate, rv.Burst)
 	s.Cache.Add(rv.Key, l)
 	rateLimitCreatedTotal.Inc()
+	return l
 }
 
 func (s *Server) runLimiter(w http.ResponseWriter, r *http.Request, wait bool) {
@@ -78,33 +79,34 @@ func (s *Server) runLimiter(w http.ResponseWriter, r *http.Request, wait bool) {
 		return
 	}
 
+	var l *rate.Limiter
+
 	if _l, ok := s.Cache.Get(rv.Key); !ok {
-		s.newLimiter(rv)
-		s.response(w, http.StatusCreated)
-		return
+		l = s.newLimiter(rv)
 	} else {
-		l := _l.(*rate.Limiter)
+		l = _l.(*rate.Limiter)
 		if rv.Rate != l.Limit() || rv.Burst != l.Burst() {
 			// renew a limiter
-			s.newLimiter(rv)
-			s.response(w, http.StatusCreated)
+			l = s.newLimiter(rv)
 		}
-		if wait {
-			if err := l.Wait(r.Context()); err != nil {
-				rateLimitHitsTotal.Inc()
-				s.response(w, http.StatusTooManyRequests)
-			} else {
-				rateLimitAllowedTotal.Inc()
-				s.response(w, http.StatusOK)
-			}
+	}
+
+	// Apply rate limiting to all requests
+	if wait {
+		if err := l.Wait(r.Context()); err != nil {
+			rateLimitHitsTotal.Inc()
+			s.response(w, http.StatusTooManyRequests)
 		} else {
-			if l.Allow() {
-				rateLimitAllowedTotal.Inc()
-				s.response(w, http.StatusOK)
-			} else {
-				rateLimitHitsTotal.Inc()
-				s.responseWithRetryAfter(w, http.StatusTooManyRequests, l)
-			}
+			rateLimitAllowedTotal.Inc()
+			s.response(w, http.StatusOK)
+		}
+	} else {
+		if l.Allow() {
+			rateLimitAllowedTotal.Inc()
+			s.response(w, http.StatusOK)
+		} else {
+			rateLimitHitsTotal.Inc()
+			s.responseWithRetryAfter(w, http.StatusTooManyRequests, l)
 		}
 	}
 }

--- a/throttled.go
+++ b/throttled.go
@@ -65,58 +65,54 @@ func parseLimitRequest(r *http.Request) (*LimitRequest, error) {
 	}, nil
 }
 
-func (s *Server) newLimiter(rv *LimitRequest) *rate.Limiter {
+func (s *Server) getLimiter(rv *LimitRequest) *rate.Limiter {
+	if _l, ok := s.Cache.Get(rv.Key); ok {
+		l := _l.(*rate.Limiter)
+		if rv.Rate == l.Limit() && rv.Burst == l.Burst() {
+			return l
+		}
+		// renew limiter when rate or burst parameters changed
+	}
 	l := rate.NewLimiter(rv.Rate, rv.Burst)
 	s.Cache.Add(rv.Key, l)
 	rateLimitCreatedTotal.Inc()
 	return l
 }
 
-func (s *Server) runLimiter(w http.ResponseWriter, r *http.Request, wait bool) {
+func (s *Server) allowHandleFunc(w http.ResponseWriter, r *http.Request) {
 	rv, err := parseLimitRequest(r)
 	if err != nil {
 		s.response(w, http.StatusBadRequest)
 		return
 	}
-
-	var l *rate.Limiter
-
-	if _l, ok := s.Cache.Get(rv.Key); !ok {
-		l = s.newLimiter(rv)
+	l := s.getLimiter(rv)
+	if l.Allow() {
+		rateLimitAllowedTotal.Inc()
+		s.response(w, http.StatusOK)
+		return
 	} else {
-		l = _l.(*rate.Limiter)
-		if rv.Rate != l.Limit() || rv.Burst != l.Burst() {
-			// renew a limiter
-			l = s.newLimiter(rv)
-		}
+		rateLimitHitsTotal.Inc()
+		s.responseWithRetryAfter(w, http.StatusTooManyRequests, l)
+		return
 	}
-
-	// Apply rate limiting to all requests
-	if wait {
-		if err := l.Wait(r.Context()); err != nil {
-			rateLimitHitsTotal.Inc()
-			s.response(w, http.StatusTooManyRequests)
-		} else {
-			rateLimitAllowedTotal.Inc()
-			s.response(w, http.StatusOK)
-		}
-	} else {
-		if l.Allow() {
-			rateLimitAllowedTotal.Inc()
-			s.response(w, http.StatusOK)
-		} else {
-			rateLimitHitsTotal.Inc()
-			s.responseWithRetryAfter(w, http.StatusTooManyRequests, l)
-		}
-	}
-}
-
-func (s *Server) allowHandleFunc(w http.ResponseWriter, r *http.Request) {
-	s.runLimiter(w, r, false)
 }
 
 func (s *Server) waitHandleFunc(w http.ResponseWriter, r *http.Request) {
-	s.runLimiter(w, r, true)
+	rv, err := parseLimitRequest(r)
+	if err != nil {
+		s.response(w, http.StatusBadRequest)
+		return
+	}
+	l := s.getLimiter(rv)
+	if err := l.Wait(r.Context()); err != nil {
+		rateLimitHitsTotal.Inc()
+		s.response(w, http.StatusTooManyRequests)
+		return
+	} else {
+		rateLimitAllowedTotal.Inc()
+		s.response(w, http.StatusOK)
+		return
+	}
 }
 
 func (s *Server) response(w http.ResponseWriter, code int) {
@@ -139,12 +135,12 @@ func (s *Server) instrumentHandler(endpoint string, handler http.HandlerFunc) ht
 func (s *Server) responseWithRetryAfter(w http.ResponseWriter, code int, limiter *rate.Limiter) {
 	w.Header().Set("Content-Type", "text/plain")
 
-	// Reserve()を使って次のトークンが利用可能になるまでの時間を計算
+	// Use Reserve() to calculate the time until the next token is available
 	r := limiter.Reserve()
 	delay := r.Delay()
-	r.Cancel() // 実際には予約しないのでキャンセル
+	r.Cancel() // Cancel the reservation since we don't actually want to reserve
 
-	// Retry-Afterヘッダーに秒数を設定（切り上げ）
+	// Set the Retry-After header with the number of seconds (rounded up)
 	retryAfterSeconds := int(math.Ceil(delay.Seconds()))
 	if retryAfterSeconds > 0 {
 		w.Header().Set("Retry-After", strconv.Itoa(retryAfterSeconds))


### PR DESCRIPTION
## Summary
- Add Retry-After header to 429 responses with calculated wait time
- Fix initial request rate limiting behavior to apply limits consistently
- Refactor code structure for better maintainability

## Key Changes
- **Retry-After Header**: 429 responses now include accurate wait time calculated from rate limiter
- **Rate Limiting Fix**: All requests now properly consume rate limit tokens (previously first request bypassed limits)
- **Code Refactoring**: Improved function organization and English comments
- **Burst=0 Behavior**: Documented behavior where burst=0 blocks all requests after limiter creation

🤖 Generated with [Claude Code](https://claude.ai/code)